### PR TITLE
Use absolute path to support Cop Exclude param

### DIFF
--- a/lib/rubocop/git/commit_file.rb
+++ b/lib/rubocop/git/commit_file.rb
@@ -6,6 +6,10 @@ class CommitFile
     @commit = commit
   end
 
+  def absolute_path
+    @file.absolute_path
+  end
+
   def filename
     @file.filename
   end

--- a/lib/rubocop/git/pseudo_resource.rb
+++ b/lib/rubocop/git/pseudo_resource.rb
@@ -1,11 +1,19 @@
 module RuboCop
   module Git
     class PseudoResource
-      attr_reader :filename, :patch
+      attr_reader :patch, :pwd, :file_relative_path
 
-      def initialize(filename)
-        @filename = filename
-        @patch    = ''
+      alias_method :filename, :file_relative_path
+
+      def initialize(file_relative_path, pwd = Dir.pwd)
+        @file_relative_path = file_relative_path
+        @pwd = pwd
+        @patch = ''
+      end
+
+      def absolute_path
+        filename
+        File.join(pwd, filename)
       end
 
       def status

--- a/lib/rubocop/git/style_checker.rb
+++ b/lib/rubocop/git/style_checker.rb
@@ -13,7 +13,7 @@ class StyleChecker
 
   def violations
     file_violations = @modified_files.map do |modified_file|
-      FileViolation.new(modified_file.filename, offenses(modified_file))
+      FileViolation.new(modified_file.absolute_path, offenses(modified_file))
     end
 
     file_violations.select do |file_violation|

--- a/lib/rubocop/git/style_guide.rb
+++ b/lib/rubocop/git/style_guide.rb
@@ -30,19 +30,19 @@ class StyleGuide
   end
 
   def excluded_file?(file)
-    config.file_to_exclude?(file.filename)
+    config.file_to_exclude?(file.absolute_path)
   end
 
   def parse_source(file)
     rubocop_version = Gem::Version.new(RuboCop::Version::STRING)
     if rubocop_version < Gem::Version.new('0.36.0')
-      RuboCop::ProcessedSource.new(file.content, file.filename)
+      RuboCop::ProcessedSource.new(file.content, file.absolute_path)
     elsif rubocop_version < Gem::Version.new('0.41.0')
       RuboCop::ProcessedSource.new(file.content,
-                                   target_ruby_version, file.filename)
+                                   target_ruby_version, file.absolute_path)
     else
       RuboCop::ProcessedSource.new(file.content,
-                                   config.target_ruby_version, file.filename)
+                                   config.target_ruby_version, file.absolute_path)
     end
   end
 


### PR DESCRIPTION
When Exclude param is used for a cop, ie:

```
Metrics/BlockLength:
  Exclude:
    - 'spec/**/*.rb'
```

Rubocop internally checks these strings using the [`match_pattern?`][1] method and since the pattern arg is given as `project root + pattern`, it never works for relative paths. It would, however, work for a path defined as regexp, ie:

```
Metrics/BlockLength:
  Exclude:
    - !ruby/regexp /spec\/.*\/.*_spec.rb$/
```

however I think it's convenient to support string paths in order to allow '**' pattern as well.

[1]: https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/path_util.rb#L17