### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/rubocop/git/style_guide.rb
+++ b/lib/rubocop/git/style_guide.rb
@@ -11,7 +11,7 @@ class RuboCop::Git::StyleGuide
       []
     else
       src = process_source(file)
-      team = RuboCop::Cop::Team.new(enabled_cops, config, rubocop_options)
+      team = RuboCop::Cop::Team.mobilize(enabled_cops, config, rubocop_options)
       team.respond_to?(:investigate) ? team.investigate(src).offenses : team.inspect_file(src)
     end
   end

--- a/rubocop-git.gemspec
+++ b/rubocop-git.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_dependency 'rubocop', '~> 1.0'
+  spec.add_dependency 'rubocop', '~> 1.0', '>= 1.38.0'
 end


### PR DESCRIPTION
This PR:

* Fixes a deprecation warning shown by recent versions of Rubocop
* Also narrows down the range of required Rubocop version, after I found out (while checking that the change didn't affect older versions) that actually, not the whole >1.0.0 is supported

See individual commits for more details.